### PR TITLE
Update glassmorphismToggle with new blur settings namespace

### DIFF
--- a/etc/skel/.config/hypr/scripts/glassmorphismToggle
+++ b/etc/skel/.config/hypr/scripts/glassmorphismToggle
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-STATE=$(hyprctl -j getoption decoration:blur_passes | jq ".int")
+STATE=$(hyprctl -j getoption decoration:blur:passes | jq ".int")
 
 if [ "${STATE}" == "2" ]; then
-  hyprctl keyword decoration:blur_size 3
-	hyprctl keyword decoration:blur_passes 1
+  hyprctl keyword decoration:blur:size 3
+	hyprctl keyword decoration:blur:passes 1
   notify-send "Normal blur"
 else
-  hyprctl keyword decoration:blur_size 7.8
-	hyprctl keyword decoration:blur_passes 2
+  hyprctl keyword decoration:blur:size 7.8
+	hyprctl keyword decoration:blur:passes 2
   notify-send "Glassmorphism activated"
 fi


### PR DESCRIPTION
Hyprland 28 had a breaking change that moved all blur values to decoration:blur:
e.g decoration:blur:size instead of decoration:blur_size instead 

See:
https://github.com/hyprwm/Hyprland/pull/2877/files#diff-9993bc2bbc311ab9e2cb878dbc44bc4f9d5edc5216b9aa3172e4b10b9b0d61f5 

This request fixed the glassmorphismToggle to use the new names.
